### PR TITLE
Add CI workflows, lockfile generator, and playbook

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Résumé
+- _Décris en quelques puces ce que contient la PR._
+
+## Tests
+- [ ] `npm run lint`
+- [ ] `npm run typecheck`
+- [ ] `npm run test`
+- [ ] `npm run build`
+
+## Docs
+- [ ] Documentation mise à jour (README, Playbook, etc.)
+
+## Notes reviewer
+- _Ajoute ici le contexte utile pour la revue (limitations, follow-ups, etc.)._

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,36 @@
 name: CI
 
 on:
-  pull_request:
   push:
-    branches: [ main ]
+    branches:
+      - "**"
+  pull_request:
 
 jobs:
-  node-ci:
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: 20
 
-      - name: Install deps
-        run: npm ci
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci
+          else
+            npm install --no-audit --fund=false
+          fi
 
       - name: Lint
         run: npm run lint --if-present
 
-      - name: Type check
+      - name: Typecheck
         run: npm run typecheck --if-present
 
       - name: Test

--- a/.github/workflows/generate-lockfile.yml
+++ b/.github/workflows/generate-lockfile.yml
@@ -1,39 +1,46 @@
 name: Generate lockfile
 
 on:
-  workflow_dispatch: {}   # tu le lances manuellement
+  workflow_dispatch:
 
 permissions:
-  contents: write         # autorise ce workflow à pousser des commits
+  contents: write
+  pull-requests: write
 
 jobs:
-  gen-lock:
+  generate:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: true   # pour pousser avec GITHUB_TOKEN
 
-      - name: Setup Node
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: 20
 
-      - name: Create lockfile (npm install)
-      # --no-audit et --fund=false pour éviter du bruit en CI
+      - name: Install dependencies
         run: npm install --no-audit --fund=false
 
-      - name: Show result
+      - name: Verify lockfile existence
         run: |
-          ls -la
-          test -f package-lock.json && echo "package-lock.json OK" || (echo "Lockfile missing" && exit 1)
+          if [ ! -f package-lock.json ]; then
+            echo "package-lock.json not found"
+            exit 1
+          fi
 
-      - name: Commit & push lockfile
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package-lock.json
-          git diff --cached --quiet && echo "No changes to commit" || git commit -m "chore: add package-lock.json"
-          git push
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: ci/add-lockfile
+          title: "chore: add package-lock.json"
+          commit-message: "chore: add package-lock.json"
+          add-paths: |
+            package-lock.json
+          body: |
+            ## Summary
+            - Add the generated package-lock.json file.
+            
+            ## Testing
+            - npm install --no-audit --fund=false

--- a/README.md
+++ b/README.md
@@ -1,18 +1,38 @@
 # Template Node CI
 
+[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
+
 Starter minimal pour projets Node/JS avec CI GitHub Actions, ESLint, Prettier et tests Vitest.
 
-## Prise en main
+## Scripts npm
 
-```bash
-npm ci
-npm run lint
-npm run test
+| Script | Description |
+| --- | --- |
+| `npm run lint` | Lance ESLint sur tout le projet. |
+| `npm run format` | Vérifie que Prettier laisserait le formatage inchangé. |
+| `npm run test` | Exécute la suite de tests Vitest en mode batch. |
+| `npm run typecheck` | _(Optionnel)_ Lance un vérificateur de types (ex. `tsc`, `tsc --noEmit`, `tsd`). |
+| `npm run build` | _(Optionnel)_ Construit l’application ou la librairie. |
 
+> Ajoute les scripts optionnels quand ton projet en a besoin : la CI les détecte automatiquement grâce à `--if-present`.
+
+## Documentation utile
+- [Playbook CI + Tests + Lint](docs/Playbook-CI-Tests.md)
+
+## Comment générer le lockfile initial ?
+1. Aller dans **GitHub → Actions → Generate lockfile (PR)**.
+2. Cliquer sur **Run workflow** et valider.
+3. Attendre que la PR `ci/add-lockfile` soit ouverte.
+4. Revue rapide puis merge : `package-lock.json` devient la référence officielle pour `npm ci`.
+
+## Structure
+```
 template-node-ci/
 ├─ .github/
+│  ├─ pull_request_template.md
 │  └─ workflows/
-│     └─ ci.yml
+│     ├─ ci.yml
+│     └─ generate-lockfile.yml
 ├─ docs/
 │  └─ Playbook-CI-Tests.md
 ├─ src/
@@ -23,4 +43,4 @@ template-node-ci/
 ├─ prettier.config.cjs
 ├─ package.json
 └─ README.md
-
+```

--- a/docs/Playbook-CI-Tests.md
+++ b/docs/Playbook-CI-Tests.md
@@ -1,49 +1,39 @@
-
----
-
-## `docs/Playbook-CI-Tests.md` (pédago + pense-bête)
-```md
 # Playbook CI + Tests + Lint
 
-Ce document t’explique **à quoi sert chaque étape**, **où elle vit** et **comment s’en servir**.
+Ce pense-bête explique **qui fait quoi**, **dans quel ordre** et **comment réagir** pour garder un projet Node/JS en bonne santé.
 
 ---
 
-## 1) Les rôles
-
-- **package.json** : liste des **scripts** que tu lances localement et que la CI relance automatiquement.
-- **CI (GitHub Actions)** : exécute tes scripts sur un serveur GitHub à chaque `push/PR`.
-- **Lint (ESLint)** : vérifie la qualité du code **sans l’exécuter** (style + pièges fréquents).
-- **Prettier** : formatage **uniforme** du code (espaces, guillemets, etc.).
-- **Tests (Vitest)** : exécutent ton code pour prouver son comportement.
-- **Build** : fabrique le livrable (optionnel pour les libs/scripts).
-
----
-
-## 2) Comment ça s’enchaîne
-
-1. **Dev** : tu écris/édites du code.
-2. **Local** : `npm run lint` → `npm run test`.
-3. **Push/PR** : la CI relance **les mêmes commandes** sur un serveur propre.
-4. Si tout est **vert** → merge en confiance. Si **rouge** → corrige avant de merger.
+## 1. Les rôles
+- **`package.json`** : catalogue des scripts qui servent à piloter lint, tests, build… localement et en CI.
+- **CI (GitHub Actions)** : relance ces scripts à chaque `push`/`pull_request` pour vérifier qu’un commit neuf passe dans un environnement propre.
+- **ESLint (lint)** : analyse statiquement ton code pour détecter bugs/anti-patterns sans l’exécuter.
+- **Prettier (format)** : remet en forme le code pour éviter les guerres de style.
+- **Vitest (tests)** : exécute les specs pour prouver que les fonctionnalités marchent.
+- **Build** : prépare le livrable final (bundle, transpilation, etc.). Optionnel mais pratique pour détecter les surprises de prod.
 
 ---
 
-## 3) Lint vs Format
-
-- **Lint** (ESLint) = règles de qualité et d’anti-erreurs (ex.: variable non utilisée).
-- **Format** (Prettier) = style visuel (guillemets, trailing commas, largeur de ligne).
-
-> Tips : pour corriger automatiquement le style, tu peux ajouter `npm run format:fix` = `prettier -w .`.
+## 2. L’enchaînement (local → CI)
+1. **Tu développes** une fonctionnalité ou fixes un bug.
+2. **Local** : lance `npm run lint`, puis `npm run test` (et `npm run typecheck`/`npm run build` si dispo).
+3. **Commit & push** : la CI GitHub redémarre sur une machine vierge.
+4. **CI** rejoue les mêmes scripts pour éviter la phrase « chez moi ça marche ».
+5. **Merge** seulement quand tout est vert.
 
 ---
 
-## 4) Tests (Vitest)
+## 3. Lint vs Format : qui fait quoi ?
+| Outil | Action | Quand l’utiliser ? |
+| --- | --- | --- |
+| **ESLint** | Signale variables inutilisées, imports manquants, règles métiers… | Après avoir modifié du code, avant de committer.
+| **Prettier** | Ajuste les espaces, guillemets, retours à la ligne. | Dès que tu veux nettoyer le style (`npm run format`).
 
-- Fichiers de test : `tests/*.test.js`.
-- Commande : `npm run test` (en CI) ou `npx vitest` (mode dev interactif).
+> Astuce : ajoute un script `"format:fix": "prettier -w ."` si tu veux tout corriger automatiquement.
 
-Exemple :
+---
+
+## 4. Exemple de test Vitest
 ```js
 import { describe, it, expect } from 'vitest';
 import { sum } from '../src/sum.js';
@@ -53,3 +43,56 @@ describe('sum', () => {
     expect(sum(2, 3)).toBe(5);
   });
 });
+```
+
+- Fichiers de test : `tests/*.test.js`.
+- Commande de base : `npm run test` (mode batch) ou `npx vitest` (watch interactif).
+
+---
+
+## 5. Pourquoi `--if-present` en CI ?
+Le workflow CI utilise `npm run <script> --if-present` pour exécuter un script **uniquement s’il existe** dans `package.json`. Résultat :
+- un template peut être cloné sans erreur même si `typecheck` ou `build` ne sont pas encore définis ;
+- chaque projet active la brique dont il a besoin, sans modifier la CI.
+
+---
+
+## 6. Routine « avant PR »
+- [ ] Mettre à jour ta branche depuis `main`.
+- [ ] Vérifier `npm run lint` (et corriger/auto-fixer si nécessaire).
+- [ ] Vérifier `npm run test` (et `npm run typecheck`/`npm run build` si le projet les fournit).
+- [ ] S’assurer que la documentation et le changelog sont à jour.
+- [ ] Relire la PR comme si tu étais reviewer (noms, logs, code mort…).
+
+---
+
+## 7. Dépannage rapide
+| Symptôme | Piste rapide |
+| --- | --- |
+| `npm install` échoue | Vérifie ta version de Node (utilise `nvm use 20`). |
+| ESLint hurle sur un import inexistant | Assure-toi que le fichier est bien renommé/exporté. |
+| Vitest ne trouve pas un module | Chemin relatif incorrect (`../` vs `./`). |
+| Build casse uniquement en CI | La CI part d’un dossier vide : ajoute les fichiers requis ou les variables d’environnement. |
+| Différents résultats entre local et CI | Supprime `node_modules`, relance `npm install` pour reproduire l’environnement propre. |
+
+---
+
+## 8. Glossaire express
+- **CI** : Continuous Integration, automatisation des vérifications à chaque commit.
+- **Lockfile** : `package-lock.json`, photo précise des versions installées.
+- **Runner** : machine virtuelle qui exécute ton workflow GitHub Actions.
+- **Script npm** : commande déclarée dans `package.json` (utilisable via `npm run <nom>`).
+
+---
+
+## 9. Check-list « nouveau projet »
+- [ ] Cloner le template et mettre à jour le `README` avec le contexte projet.
+- [ ] Personnaliser `package.json` (nom, scripts, dépendances).
+- [ ] Exécuter l’action **Generate lockfile (PR)** pour créer `package-lock.json`.
+- [ ] Configurer les secrets nécessaires pour la CI (si build déploiement, etc.).
+- [ ] Activer les protections de branche (`main` protégée, revue obligatoire).
+- [ ] Compléter la documentation métier/technique (docs/, Notion, etc.).
+
+---
+
+Garde ce playbook à portée de main : il évite la dette technique et rassure les reviewers. 🙌


### PR DESCRIPTION
## Summary
- add a Node 20 CI workflow that installs dependencies adaptively and runs optional project scripts
- create a manual workflow that generates a lockfile and opens a pull request, plus a PR template for contributors
- refresh the documentation with a CI/testing playbook, README badge placeholder, and lockfile generation guidance

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfb1c882848322bd59400b8da80b8b